### PR TITLE
Fix nav low contrast

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -167,7 +167,7 @@ img {
         width: 70%;
         height: 100%;
         padding: 3.5rem 1.5rem 0;
-        background: rgba(255, 255, 255, .3);
+        background: var(--dark-color);
         backdrop-filter: blur(10px);
         transition: .5s;
     }


### PR DESCRIPTION
Fixed the low contrast on the nav menu on mobile screens. Changed the background Color to var(dark--)

Fixes #47 

**Screenshot**

![image](https://user-images.githubusercontent.com/74750414/117806956-9de85200-b278-11eb-9fc7-aad9b79f56df.png)
