### PR TITLE
Fix text color under footer__credits

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -928,7 +928,11 @@ h2 {
 .pre__list {
   text-align: center;
 }
+.powered__by {
+  margin-bottom: 15px;
+}
 .list__link {
+  color: #fff;
   display: inline-flex;
   justify-content: center;
   padding-left: 1px;

--- a/index.html
+++ b/index.html
@@ -613,10 +613,21 @@
         </ul>
         <p class="footer__copy">&#169; 2021 SurPath Hub. All rights reserved</p>
         
-        <p class = "footer__credits">Powered by
+        <p class="footer__credits">
             <ul class="pre__list">
-             <li><a class = "list__link" href="https://github.com/" target="_blank"><span>GitHub<img class ="list__link" src="https://img.icons8.com/ios-glyphs/30/ffffff/github.png"/></a></li>
-             <li><span><a class="list__link" href="https://devprotocol.xyz/" target="_blank">Dev Protocol<img class ="list__link" src="https://user-images.githubusercontent.com/73097560/130181401-80312b73-1642-4009-affc-e10daf976025.png" height="30px" width="30px"></a></span></li>
+                <li class="powered__by">Powered by:</li>
+                <li>
+                    <a class="list__link" href="https://github.com/" target="_blank">
+                        <img class="list__link" src="https://img.icons8.com/ios-glyphs/30/ffffff/github.png">
+                        &nbsp;GitHub
+                    </a>
+                </li>
+                <li>
+                    <a class="list__link" href="https://devprotocol.xyz/" target="_blank">
+                        <img class="list__link" src="https://user-images.githubusercontent.com/73097560/130181401-80312b73-1642-4009-affc-e10daf976025.png" height="30px" width="30px">
+                        &nbsp;Dev Protocol
+                    </a>
+                </li>
             </ul>
         </p>
     </footer>


### PR DESCRIPTION
## Related Issue 

Closes: #91

### Describe the changes you've made

- Added colon in the "Powered by" (`Powered by:`)
- Changed the text color of "GitHub" and "Dev Protocol" to white (`#fff`)
- Moved the logo before the text
- Aligned the GitHub's logo and its text
- Fixed code spaces and nested indention

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 ![image1](https://user-images.githubusercontent.com/84888155/130387020-fdec2a84-1432-4149-a55e-f0cfef6040e0.png) | ![image2](https://user-images.githubusercontent.com/84888155/130387071-05f119ef-b75d-44bc-9a74-3c5c84250dff.png) |
